### PR TITLE
shorten db initialization command and put a placeholder on the execution

### DIFF
--- a/{{cookiecutter.app_name}}/setup.py
+++ b/{{cookiecutter.app_name}}/setup.py
@@ -60,7 +60,7 @@ setup(
             'main = {{ cookiecutter.app_name }}:main',
         ],
         'console_scripts': [
-            'initialize_{{ cookiecutter.app_name }}_db={{ cookiecutter.app_name }}.scripts.initialize_db:main',
+            'initdb={{ cookiecutter.app_name }}.scripts.initialize_db:main',
         ],
     },
 )

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/scripts/initialize_db.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/scripts/initialize_db.py
@@ -4,17 +4,12 @@ import sys
 from pyramid.paster import bootstrap, setup_logging
 from sqlalchemy.exc import OperationalError
 
-from .. import models
-
 
 def setup_models(dbsession):
     """
     Add or update models / fixtures in the database.
 
     """
-    model = models.user.User(username='foobar', email='foo@bar.com',
-                             password='mypass')
-    dbsession.add(model)
 
 
 def parse_args(argv):


### PR DESCRIPTION
Shorten db initialization command and put a placeholder on its execution instead of having it initialize a db.