### PR TITLE
remove detail instruction printing post generation

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,13 +1,10 @@
 import os
-import sys
-from textwrap import dedent
 
 WORKING = os.path.abspath(os.path.curdir)
 
 
 def main():
     clean_unused_template_settings()
-    display_actions_message()
 
 
 def clean_unused_template_settings():
@@ -32,66 +29,6 @@ def delete_other_ext(directory, extension):
                 os.unlink(os.path.join(root, template_file))
 
 
-def display_actions_message():
-    WIN = sys.platform.startswith('win')
-
-    venv = 'env'
-    if WIN:
-        venv_cmd = 'py -3 -m venv'
-        venv_bin = os.path.join(venv, 'Scripts')
-    else:
-        venv_cmd = 'python3 -m venv'
-        venv_bin = os.path.join(venv, 'bin')
-
-    env_setup = dict(
-        separator='=' * 79,
-        venv=venv,
-        venv_cmd=venv_cmd,
-        pip_cmd=os.path.join(venv_bin, 'pip'),
-        pytest_cmd=os.path.join(venv_bin, 'pytest'),
-        pserve_cmd=os.path.join(venv_bin, 'pserve'),
-        alembic_cmd=os.path.join(venv_bin, 'alembic'),
-        init_cmd=os.path.join(
-            venv_bin, 'initdb'),
-    )
-    msg = dedent(
-        """
-        %(separator)s
-        Documentation: https://docs.pylonsproject.org/projects/pyramid/en/latest/
-        Tutorials:     https://docs.pylonsproject.org/projects/pyramid_tutorials/en/latest/
-        Twitter:       https://twitter.com/PylonsProject
-        Mailing List:  https://groups.google.com/forum/#!forum/pylons-discuss
-        Welcome to Pyramid.  Sorry for the convenience.
-        %(separator)s
-
-        Change directory into your newly created project.
-            cd {{ cookiecutter.app_name }}
-
-        Create a Python virtual environment.
-            %(venv_cmd)s %(venv)s
-
-        Upgrade packaging tools.
-            %(pip_cmd)s install --upgrade pip setuptools
-
-        Install the project in editable mode with its testing requirements.
-            %(pip_cmd)s install -e ".[testing]"
-
-        Migrate the database using Alembic.
-            # Generate your first revision.
-            %(alembic_cmd)s -c development.ini revision --autogenerate -m "init"
-            # Upgrade to that revision.
-            %(alembic_cmd)s -c development.ini upgrade head
-            # Load default data.
-            %(init_cmd)s development.ini
-
-        Run your project's tests.
-            %(pytest_cmd)s
-
-        Run your project.
-            %(pserve_cmd)s development.ini
-        """ % env_setup)
-    print(msg)
-
-
 if __name__ == '__main__':
     main()
+    print("Check {{cookiecutter.app_name}}/README.txt file for next steps")

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -83,13 +83,7 @@ def test_project(cookies, venv, capfd, template):
 
     out, err = capfd.readouterr()
 
-    if WIN:
-        assert 'Scripts\\pserve' in out
-        for idx, project_file in enumerate(project_files):
-            project_files[idx] = project_file.replace('/', '\\')
-        project_files.sort()
-    else:
-        assert 'bin/pserve' in out
+    assert 'myapp/README.txt' in out
 
     files = build_files_list(str(result.project))
     files.sort()


### PR DESCRIPTION
Remove instruction printing after project generation. This will help us avoid having different instructions at different locations